### PR TITLE
Export more server stats

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,25 @@ fn main() {
     let busytime = register_int_gauge!("nfs_nfsd_busytime",
         "Total time in ns that nfsd was busy with at least one opeartion")
         .expect("can not create gauge");
+
+    let cache_inprog = register_int_gauge!("nfs_nfsd_cache_in_progress_hits",
+        "Server cache in-progress hits")
+        .expect("can not create gauge");
+    // Don't publish Idem.  It's always 0
+    let cache_nonidempotent = register_int_gauge!(
+        "nfs_nfsd_cache_nonidempotent_hits",
+        "Server cache non-idempotent hits")
+        .expect("can not create gauge");
+    let cache_misses = register_int_gauge!("nfs_nfsd_server_cache_misses",
+        "Server cache misses")
+        .expect("can not create gauge");
+    let cache_size = register_int_gauge!("nfs_nfsd_server_cache_size",
+        "Server cache size in entries")
+        .expect("can not create gauge");
+    let cache_tcppeak = register_int_gauge!("nfs_nfsd_server_cache_tcp_peak",
+        "Peak size of the NFS server's TCP client cache")
+        .expect("can not create gauge");
+
     let clients = register_int_gauge!("nfs_nfsd_clients",
         "Number of connected NFS v4.0+ clients")
         .expect("can not create gauge");
@@ -139,12 +158,22 @@ fn main() {
             startcnt.set(nfs_stat.startcnt.try_into().unwrap());
             donecnt.set(nfs_stat.donecnt.try_into().unwrap());
             busytime.set(nfs_stat.busytime.try_into().unwrap());
+
+            cache_inprog.set(nfs_stat.server_cache.inprog.try_into().unwrap());
+            cache_nonidempotent.set(
+                nfs_stat.server_cache.nonidem.try_into().unwrap());
+            cache_misses.set(nfs_stat.server_cache.misses.try_into().unwrap());
+            cache_size.set(nfs_stat.server_cache.size.try_into().unwrap());
+            cache_tcppeak.set(
+                nfs_stat.server_cache.tcp_peak.try_into().unwrap());
+
             clients.set(nfs_stat.server_misc.clients.try_into().unwrap());
             delegs.set(nfs_stat.server_misc.delegs.try_into().unwrap());
             lock_owner.set(nfs_stat.server_misc.lock_owner.try_into().unwrap());
             locks.set(nfs_stat.server_misc.locks.try_into().unwrap());
             open_owner.set(nfs_stat.server_misc.open_owner.try_into().unwrap());
             opens.set(nfs_stat.server_misc.opens.try_into().unwrap());
+
             set_rpcs!(Access, access);
             set_rpcs!(BackChannelCtl, backchannelctrl);
             set_rpcs!(BindConnToSess, bindconntosess);

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,7 +110,7 @@ fn main() {
         .expect("can not create gauge");
 
     let clients = register_int_gauge!("nfs_nfsd_clients",
-        "Number of connected NFS v4.0+ clients")
+        "Number of connected NFS v4.x clients")
         .expect("can not create gauge");
     let delegs = register_int_gauge!("nfs_nfsd_delegations",
         "Number of active NFS delegations")
@@ -126,7 +126,7 @@ fn main() {
         "Number of active NFS v4.0 Open Owners")
         .expect("can not create gauge");
     let opens = register_int_gauge!("nfs_nfsd_opens",
-        "Number of NFS v4.0+ open files?")
+        "Number of NFS v4.x open files?")
         .expect("can not create gauge");
     // Don't publish server_misc.retfailed.  As of this writing, it is always 0.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ fn main() {
             macro_rules! set_rpcs {
                 ($label:ident, $field:ident) => {
                     rpcs.with_label_values(&[stringify!($label)])
-                        .set(nfs_stat.$field.try_into().unwrap());
+                        .set(nfs_stat.server_rpcs.$field.try_into().unwrap());
                 };
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,26 @@ fn main() {
     let busytime = register_int_gauge!("nfs_nfsd_busytime",
         "Total time in ns that nfsd was busy with at least one opeartion")
         .expect("can not create gauge");
-
+    let clients = register_int_gauge!("nfs_nfsd_clients",
+        "Number of connected NFS v4.0+ clients")
+        .expect("can not create gauge");
+    let delegs = register_int_gauge!("nfs_nfsd_delegations",
+        "Number of active NFS delegations")
+        .expect("can not create gauge");
+    // Don't publish server_misc.faults.  As of this writing, it is always 0.
+    let lock_owner = register_int_gauge!("nfs_nfsd_lock_owners",
+        "Number of active NFS lock owners")
+        .expect("can not create gauge");
+    let locks = register_int_gauge!("nfs_nfsd_locks",
+        "Number of active NFS locks")
+        .expect("can not create gauge");
+    let open_owner = register_int_gauge!("nfs_nfsd_open_owners",
+        "Number of active NFS v4.0 Open Owners")
+        .expect("can not create gauge");
+    let opens = register_int_gauge!("nfs_nfsd_opens",
+        "Number of NFS v4.0+ open files?")
+        .expect("can not create gauge");
+    // Don't publish server_misc.retfailed.  As of this writing, it is always 0.
 
     loop {
         // Will block until exporter receives http request.
@@ -120,6 +139,12 @@ fn main() {
             startcnt.set(nfs_stat.startcnt.try_into().unwrap());
             donecnt.set(nfs_stat.donecnt.try_into().unwrap());
             busytime.set(nfs_stat.busytime.try_into().unwrap());
+            clients.set(nfs_stat.server_misc.clients.try_into().unwrap());
+            delegs.set(nfs_stat.server_misc.delegs.try_into().unwrap());
+            lock_owner.set(nfs_stat.server_misc.lock_owner.try_into().unwrap());
+            locks.set(nfs_stat.server_misc.locks.try_into().unwrap());
+            open_owner.set(nfs_stat.server_misc.open_owner.try_into().unwrap());
+            opens.set(nfs_stat.server_misc.opens.try_into().unwrap());
             set_rpcs!(Access, access);
             set_rpcs!(BackChannelCtl, backchannelctrl);
             set_rpcs!(BindConnToSess, bindconntosess);

--- a/src/nfs.rs
+++ b/src/nfs.rs
@@ -25,19 +25,9 @@ pub struct PerRWC {
     pub commit: u64,
 }
 
+/// Counts of every RPC processed
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct NfsStat {
-    pub bytes: PerRW,
-    /// Cumulative duration spent processing each operation, in nanoseconds.
-    /// May wrap!
-    pub duration: PerRWC,
-    /// Total number of operations that have been started since boot
-    pub startcnt: u64,
-    /// Total number of operations that have completed since boot
-    pub donecnt: u64,
-    /// Total time in ns that nfsd was busy with at least one operation.
-    /// May wrap!
-    pub busytime: u64,
+pub struct PerRPC {
     pub access: u64,
     pub backchannelctrl: u64,
     pub bindconntosess: u64,
@@ -105,6 +95,24 @@ pub struct NfsStat {
     pub write: u64,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct NfsStat {
+    /// Total time in ns that nfsd was busy with at least one operation.
+    /// May wrap!
+    pub busytime: u64,
+    /// Total bytes processed by each operation
+    pub bytes: PerRW,
+    /// Total number of operations that have completed since boot
+    pub donecnt: u64,
+    /// Cumulative duration spent processing each operation, in nanoseconds.
+    /// May wrap!
+    pub duration: PerRWC,
+    /// Count of each RPC processed by the server
+    pub server_rpcs: PerRPC,
+    /// Total number of operations that have been started since boot
+    pub startcnt: u64,
+}
+
 pub fn collect() -> Result<NfsStat> {
     let mut raw = ffi::nfsstatsv1::default();
     raw.vers = ffi::NFSSTATS_V1 as i32;
@@ -116,20 +124,16 @@ pub fn collect() -> Result<NfsStat> {
         }
         raw
     };
+    let bytes = PerRW {
+        read: raw.srvbytes[ffi::NFSV4OP_READ as usize],
+        write: raw.srvbytes[ffi::NFSV4OP_WRITE as usize],
+    };
     let duration = PerRWC {
         read: bintime_to_ns(&raw.srvduration[ffi::NFSV4OP_READ as usize]),
         write: bintime_to_ns(&raw.srvduration[ffi::NFSV4OP_WRITE as usize]),
         commit: bintime_to_ns(&raw.srvduration[ffi::NFSV4OP_COMMIT as usize]),
     };
-	Ok(NfsStat{
-        bytes: PerRW {
-            read: raw.srvbytes[ffi::NFSV4OP_READ as usize],
-            write: raw.srvbytes[ffi::NFSV4OP_WRITE as usize],
-        },
-        duration,
-        startcnt: raw.srvstartcnt,
-        donecnt: raw.srvdonecnt,
-        busytime: bintime_to_ns(&raw.busytime),
+    let server_rpcs = PerRPC {
         access: raw.srvrpccnt[ffi::NFSV4OP_ACCESS as usize],
         backchannelctrl: raw.srvrpccnt[ffi::NFSV4OP_BACKCHANNELCTL as usize],
         bindconntosess: raw.srvrpccnt[ffi::NFSV4OP_BINDCONNTOSESS as usize],
@@ -195,5 +199,13 @@ pub fn collect() -> Result<NfsStat> {
         verify: raw.srvrpccnt[ffi::NFSV4OP_VERIFY as usize],
         wantdeleg: raw.srvrpccnt[ffi::NFSV4OP_WANTDELEG as usize],
         write: raw.srvrpccnt[ffi::NFSV4OP_WRITE as usize],
+    };
+	Ok(NfsStat{
+        bytes,
+        duration,
+        startcnt: raw.srvstartcnt,
+        donecnt: raw.srvdonecnt,
+        busytime: bintime_to_ns(&raw.busytime),
+        server_rpcs
     })
 }


### PR DESCRIPTION
With these three commits, the nfs-exporter now exports everything reported by `nfsstat -sE` (except for three always-zero stats.  It's probably a bug that they're always zero; I'm checking upstream).