### PR TITLE
Don't read some obsolete stats.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,6 @@ fn main() {
     let delegs = register_int_gauge!("nfs_nfsd_delegations",
         "Number of active NFS delegations")
         .expect("can not create gauge");
-    // Don't publish server_misc.faults.  As of this writing, it is always 0.
     let lock_owner = register_int_gauge!("nfs_nfsd_lock_owners",
         "Number of active NFS lock owners")
         .expect("can not create gauge");
@@ -128,7 +127,6 @@ fn main() {
     let opens = register_int_gauge!("nfs_nfsd_opens",
         "Number of NFS v4.x open files?")
         .expect("can not create gauge");
-    // Don't publish server_misc.retfailed.  As of this writing, it is always 0.
 
     loop {
         // Will block until exporter receives http request.

--- a/src/nfs.rs
+++ b/src/nfs.rs
@@ -99,7 +99,6 @@ pub struct PerRPC {
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ServerCache {
     pub inprog: u64,
-    pub idem: u64,
     pub nonidem: u64,
     pub misses: u64,
     pub size: u64,
@@ -109,15 +108,13 @@ pub struct ServerCache {
 /// Miscellaneous NFS server stats
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ServerMisc {
-    /// Number of currently connectec NFS v4.0+ clients?
+    /// Number of currently connected NFS v4.0+ clients?
     pub clients: u64,
     pub delegs: u64,
-    pub faults: u64,
     pub lock_owner: u64,
     pub locks: u64,
     pub open_owner: u64,
     pub opens: u64,
-    pub retfailed: u64,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -162,7 +159,6 @@ pub fn collect() -> Result<NfsStat> {
     };
     let server_cache = ServerCache {
         inprog: raw.srvcache_inproghits,
-        idem: raw.srvcache_idemdonehits,
         nonidem: raw.srvcache_nonidemdonehits,
         misses: raw.srvcache_misses,
         size: i64::max(0, i64::from(raw.srvcache_size)) as u64,
@@ -171,12 +167,10 @@ pub fn collect() -> Result<NfsStat> {
     let server_misc = ServerMisc {
         clients: raw.srvclients,
         delegs: raw.srvdelegates,
-        faults: raw.srvrpc_errs,
         lock_owner: raw.srvlockowners,
         locks: raw.srvlocks,
         open_owner: raw.srvopenowners,
         opens: raw.srvopens,
-        retfailed: raw.srv_errs,
     };
     let server_rpcs = PerRPC {
         access: raw.srvrpccnt[ffi::NFSV4OP_ACCESS as usize],


### PR DESCRIPTION
These have never published useful information, and have recently been removed
upstream.  nfs-expotert already wasn't publishing them; now it doesn't even
read them at all.

See Also: https://svnweb.freebsd.org/base?view=revision&revision=366992