### PR TITLE
Fix a subtle threading problem.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased] - ReleaseDate
+
+### Fixed
+
+- Correctly start Casper from a single-threaded context.
+  (#[22](https://github.com/Axcient/freebsd-nfs-exporter/pull/22))
+
 ## [0.4.0] - 2023-02-17
 
 ### Added

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,12 +62,14 @@ fn main() {
     let ia: IpAddr = addr.parse().unwrap();
     let sa = SocketAddr::new(ia, port.parse().unwrap());
 
-    // Start exporter.
+    // Start Casper .  Safe because we're still single-threaded.
+    let casper = unsafe {Casper::new().unwrap()};
+    let mut cap_nfs = casper.nfsstat().unwrap();
+
+    // Start exporter, which creates additional threads.
     let exporter = prometheus_exporter::start(sa).unwrap();
 
     // Enter capability mode.
-    let casper = unsafe {Casper::new().unwrap()};
-    let mut cap_nfs = casper.nfsstat().unwrap();
     capsicum::enter().unwrap();
 
     // Create metrics


### PR DESCRIPTION
cap_init, called by Casper::new() forks but does not exec.  That is technically only safe to do from a single-threaded context.  From a multithreaded context only async-signal-safe functions may be called. The initial Capsicum version of the nfs-exporter started its prometheus service before starting Casper, and the Prometheus module spawns threads under-the-hood.  Everything worked in my limited testing, but there's no guarantee that it would continue to work.

Do stuff in the right order this time.