### PR TITLE
Misc preparation for the next release

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,11 +17,11 @@ common: &COMMON
 
 task:
   env:
-    VERSION: 1.66.0
+    VERSION: 1.69.0
   matrix:
-    - name: FreeBSD 13.1 MSRV
+    - name: FreeBSD 13.2 MSRV
       freebsd_instance:
-        image: freebsd-13-1-release-amd64
+        image: freebsd-13-2-release-amd64
     - name: FreeBSD 12.4 MSRV
       freebsd_instance:
         image: freebsd-12-4-release-amd64
@@ -29,11 +29,11 @@ task:
   before_cache_script: rm -rf $HOME/.cargo/registry/index
 
 task:
-  name: FreeBSD 13.1 nightly
+  name: FreeBSD 13.2 nightly
   env:
     VERSION: nightly
   freebsd_instance:
-    image: freebsd-13-1-release-amd64
+    image: freebsd-13-2-release-amd64
   << : *COMMON
   clippy_script:
     - . $HOME/.cargo/env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,30 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 1.0.109",
+ "which",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.66.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+dependencies = [
+ "bitflags 2.3.3",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.23",
  "which",
 ]
 
@@ -69,11 +92,9 @@ checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 [[package]]
 name = "capsicum"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c14628fc0be4956e4036625c64885c96cee9ba582d1b1a9a60e7e1f28ad1b68"
+source = "git+https://github.com/dlrobertson/capsicum-rs?rev=39598226e45623bcf78c16f0a1cb6014242a1693#39598226e45623bcf78c16f0a1cb6014242a1693"
 dependencies = [
  "casper-sys",
- "const-cstr",
  "ctor",
  "libc",
  "libnv",
@@ -84,8 +105,7 @@ dependencies = [
 [[package]]
 name = "casper-sys"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a301fa9fcd17d497244e16d189e4543267617d954e82000b5bb23e6380ccc3d"
+source = "git+https://github.com/dlrobertson/capsicum-rs?rev=39598226e45623bcf78c16f0a1cb6014242a1693#39598226e45623bcf78c16f0a1cb6014242a1693"
 dependencies = [
  "libnv-sys",
 ]
@@ -153,7 +173,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -166,10 +186,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-cstr"
-version = "0.3.0"
+name = "cstr"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3d0b5ff30645a68f35ece8cea4556ca14ef8a1651455f789a099a0513532a6"
+checksum = "8aa998c33a6d3271e3678950a22134cd7dd27cef86dee1b611b5b14207d1d90b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "ctor"
@@ -178,7 +202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -241,10 +265,10 @@ name = "freebsd-nfs-exporter"
 version = "0.4.2"
 dependencies = [
  "bincode",
- "bindgen",
+ "bindgen 0.66.1",
  "capsicum",
  "clap",
- "const-cstr",
+ "cstr",
  "env_logger",
  "prometheus_exporter",
  "serde",
@@ -265,9 +289,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "humantime"
@@ -359,7 +383,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a95209ae78318c727f051e39f93e9a102296a2c692f7d5d53a541a4dd632653"
 dependencies = [
- "bindgen",
+ "bindgen 0.64.0",
  "libc",
  "regex",
 ]
@@ -459,6 +483,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92139198957b410250d43fad93e630d956499a625c527eda65175c8680f83387"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.23",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,7 +501,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -527,9 +561,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -600,7 +634,7 @@ checksum = "4fc80d722935453bcafdc2c9a73cd6fac4dc1938f0346035d84bf99fa9e33217"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -633,6 +667,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,7 +703,7 @@ checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Alan Somers <asomers@axcient.com>"]
 license = "MIT/Apache-2.0"
 edition = "2018"
 repository = "https://github.com/Axcient/freebsd-nfs-exporter.git"
+rust-version = "1.69"
 keywords = ["prometheus", "monitoring", "nfs", "freebsd"]
 exclude = [
     "/.gitignore",
@@ -18,12 +19,15 @@ path = "src/main.rs"
 [dependencies]
 bincode = "1.3.0"
 clap = { version = "4.0", default-features = true, features = ["cargo", "derive"] }
+cstr = "0.2.11"
 env_logger = "0.10"
 prometheus_exporter = "0.8.4"
 capsicum = { version = "0.2.0", features = ["casper"] }
-const-cstr = "0.3.0"
 serde = "1.0.60"
 serde_derive = "1.0"
 
 [build-dependencies]
-bindgen = { version = "0.64.0", features=[] }
+bindgen = { version = "0.66.0", features=[] }
+
+[patch.crates-io]
+capsicum = { git = "https://github.com/dlrobertson/capsicum-rs", rev = "39598226e45623bcf78c16f0a1cb6014242a1693" }

--- a/src/cap_nfs.rs
+++ b/src/cap_nfs.rs
@@ -1,14 +1,14 @@
 //! A Casper service that provides NFS stats to capsicumized programs.
-use std::io;
+use std::{ffi::CStr, io};
 
 use capsicum::casper::{self, NvError, NvFlag, NvList, ServiceRegisterFlags};
-use const_cstr::{ConstCStr, const_cstr};
+use cstr::cstr;
 
 use crate::nfs;
 
 struct CapNfs {}
 impl casper::Service for CapNfs {
-    const SERVICE_NAME: ConstCStr = const_cstr!("nfs");
+    const SERVICE_NAME: &'static CStr = cstr!("nfs");
 
     fn cmd(
         cmd: &str,


### PR DESCRIPTION
* Upgrade Capsicum to 0.3.0
* Upgrade CI image to FreeBSD 13.2
* Upgrade bindgen to 0.64.0.  I expect libnv-sys to do the same before we release.
* Upgrade hermit-abi to 0.3.2.  We don't even build it, but this makes cargo-audit shut up.

https://rustsec.org/advisories/RUSTSEC-2023-0020