### PR TITLE
Update shlex to 1.3.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -40,7 +40,7 @@ task:
     - rustup component add clippy
     - cargo clippy --all-targets -- -D warnings
   audit_script:
+    - pkg install -y cargo-audit
     - . $HOME/.cargo/env
-    - cargo install cargo-audit
     - cargo audit
   before_cache_script: rm -rf $HOME/.cargo/registry/index

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smallvec"


### PR DESCRIPTION
This fixes RUSTSEC-2024-0006.  In this crate shlex is only used at build-time, so I don't think we need to make a new release and update the port.

https://rustsec.org/advisories/RUSTSEC-2024-0006