### PR TITLE
Update capsicum to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,9 +118,9 @@ checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "capsicum"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f75c2a91197eecfdb2e0b868f956e253110153100e19aef6e60bc9fd5d1e5bd"
+checksum = "34493d4fc3860e57a1c09a266f76c5a92685659af0d4bf5ca87afcf0379d6663"
 dependencies = [
  "casper-sys",
  "ctor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ bincode = "1.3.0"
 clap = { version = "4.1", default-features = true, features = ["cargo", "derive"] }
 env_logger = "0.10"
 prometheus_exporter = "0.8.4"
-capsicum = { version = "0.3.0", features = ["casper"] }
+capsicum = { version = "0.4.1", features = ["casper"] }
 serde = "1.0.63"
 serde_derive = "1.0"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ fn main() {
     let sa = SocketAddr::new(ia, cli.port);
 
     // Start Casper .  Safe because we're still single-threaded.
-    let casper = unsafe {Casper::new().unwrap()};
+    let mut casper = unsafe {Casper::new().unwrap()};
     let mut cap_nfs = casper.nfsstat().unwrap();
 
     // Start exporter, which creates additional threads.


### PR DESCRIPTION
This fixes some bugs, but none that affected nfs-exporter.  So no need to build a new release.