### PR TITLE
Convert the crate to use axum

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,7 +17,7 @@ common: &COMMON
 
 task:
   env:
-    VERSION: 1.77.0
+    VERSION: 1.81.0
   matrix:
     - name: FreeBSD 13.5 MSRV
       freebsd_instance:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased] - ReleaseDate
+
+- Handle `ECONNABORTED` errors without exiting.  This completely removes
+  dependencies on the unmaintained `prometheus-exporter` and `tiny-http`
+  crates.
+  (#[44](https://github.com/Axcient/freebsd-nfs-exporter/pull/44))
+
 ## [0.4.4] - 2024-05-22
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.1"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
@@ -61,16 +61,62 @@ dependencies = [
 ]
 
 [[package]]
-name = "ascii"
-version = "1.1.0"
+name = "atomic-waker"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "axum"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "bincode"
@@ -117,6 +163,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
 name = "capsicum"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,15 +192,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.82"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,12 +205,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chunked_transfer"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca491388666e04d7248af3f60f0c40cfb0991c72205595d7c396e3510207d1a"
 
 [[package]]
 name = "clang-sys"
@@ -243,37 +280,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
-name = "env_logger"
-version = "0.10.0"
+name = "env_filter"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
 dependencies = [
- "humantime",
- "is-terminal",
  "log",
  "regex",
- "termcolor",
 ]
 
 [[package]]
-name = "errno"
-version = "0.3.2"
+name = "env_logger"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
- "errno-dragonfly",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -286,14 +312,50 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 name = "freebsd-nfs-exporter"
 version = "0.4.4"
 dependencies = [
+ "axum",
  "bincode",
  "bindgen",
  "capsicum",
  "clap",
  "env_logger",
- "prometheus_exporter",
+ "log",
+ "prometheus",
  "serde",
  "serde_derive",
+ "tokio",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
 ]
 
 [[package]]
@@ -309,10 +371,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.2"
+name = "http"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -321,20 +417,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
+name = "hyper"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.9"
+name = "hyper-util"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
- "hermit-abi",
- "rustix",
- "windows-sys 0.48.0",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -342,6 +458,36 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "lazy_static"
@@ -357,9 +503,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libloading"
@@ -394,12 +540,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
-
-[[package]]
 name = "lock_api"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,9 +551,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -422,10 +568,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "nom"
@@ -473,6 +636,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,18 +680,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prometheus"
-version = "0.13.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
  "cfg-if",
  "fnv",
@@ -506,19 +702,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prometheus_exporter"
-version = "0.8.5"
-source = "git+https://github.com/AlexanderThaller/prometheus_exporter?rev=c49efe6#c49efe614486f998b20eb410ae0caf3e904cf540"
-dependencies = [
- "ascii",
- "either",
- "log",
- "prometheus",
- "thiserror",
- "tiny_http",
-]
-
-[[package]]
 name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,9 +709,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
@@ -578,19 +761,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustix"
-version = "0.38.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "172891ebdceb05aa0005f533a6cbfca599ddd7d966f6f5d4d9b2e70478e70399"
-dependencies = [
- "bitflags 2.3.3",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,15 +768,27 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.185"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.183"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -621,9 +803,19 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "strsim"
@@ -633,9 +825,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "2a26dbd934e5451d21ef060c018dae56fc073894c5a7896f882928a76e6d081b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -643,28 +835,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.2.0"
+name = "sync_wrapper"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
-dependencies = [
- "winapi-util",
-]
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "thiserror"
-version = "1.0.44"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.44"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -672,16 +861,56 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny_http"
-version = "0.12.0"
+name = "tokio"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
- "ascii",
- "chunked_transfer",
- "httpdate",
- "log",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "unicode-ident"
@@ -700,6 +929,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "which"
@@ -729,19 +964,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -759,6 +991,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -785,11 +1035,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -805,6 +1072,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,6 +1088,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -829,10 +1108,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -847,6 +1138,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,6 +1154,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -871,6 +1174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,3 +1190,9 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ clap = { version = "4.1", default-features = true, features = ["cargo", "derive"
 env_logger = "0.11"
 capsicum = { version = "0.4.1", features = ["casper"] }
 log = "0.4.27"
-serde = "1.0.63"
-serde_derive = "1.0"
+serde = "1.0.69"
+serde_derive = "1.0.69"
 prometheus = {version = "0.14.0", default-features = false, features = [] }
 tokio = { version = "^1.25", features = ["macros", "net", "rt"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,11 @@
 name = "freebsd-nfs-exporter"
 description = "Prometheus exporter for FreeBSD NFS stats"
 version = "0.4.4"
-authors = ["Alan Somers <asomers@axcient.com>"]
+authors = ["Alan Somers <Alan.Somers@ConnectWise.com>"]
 license = "MIT/Apache-2.0"
 edition = "2021"
 repository = "https://github.com/Axcient/freebsd-nfs-exporter.git"
-rust-version = "1.77"
+rust-version = "1.81"
 keywords = ["prometheus", "monitoring", "nfs", "freebsd"]
 exclude = [
     "/.gitignore",
@@ -17,16 +17,16 @@ name = "nfs-exporter"
 path = "src/main.rs"
 
 [dependencies]
+axum = { version = "0.8", default-features = false, features = ["http1", "tokio"] }
 bincode = "1.3.0"
 clap = { version = "4.1", default-features = true, features = ["cargo", "derive"] }
-env_logger = "0.10"
-prometheus_exporter = "0.8.4"
+env_logger = "0.11"
 capsicum = { version = "0.4.1", features = ["casper"] }
+log = "0.4.27"
 serde = "1.0.63"
 serde_derive = "1.0"
+prometheus = {version = "0.14.0", default-features = false, features = [] }
+tokio = { version = "^1.25", features = ["macros", "net", "rt"] }
 
 [build-dependencies]
 bindgen = { version = "0.66.0", features=[] }
-
-[patch.crates-io]
-prometheus_exporter = { git = "https://github.com/AlexanderThaller/prometheus_exporter", rev = "c49efe6" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,35 @@
 // vim: tw=80
 
-use std::net::{IpAddr, SocketAddr};
+use std::{
+    io,
+    net::{IpAddr, SocketAddr},
+    process::exit,
+    sync::{Arc, LazyLock, Mutex},
+};
 
+use axum::{
+    extract::{ConnectInfo, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
 use capsicum::casper::Casper;
 use clap::{crate_version, CommandFactory, Parser};
 use env_logger::{Builder, Env};
-use prometheus_exporter::prometheus::{register_gauge, register_gauge_vec};
+use prometheus::{
+    register_gauge,
+    register_gauge_vec,
+    Gauge,
+    GaugeVec,
+    TextEncoder,
+};
+use tokio::net::TcpListener;
 
 mod cap_nfs;
 mod nfs;
 
-use cap_nfs::CasperExt;
+use cap_nfs::{CapNfsAgent, CasperExt};
 
 #[derive(Parser, Clone, Debug)]
 #[clap(version = crate_version!())]
@@ -30,7 +49,259 @@ struct Cli {
     port:   u16,
 }
 
-fn main() {
+struct AppState {
+    server:        bool,
+    // Annoyingly, axum requires AppState to be Send, even though we're using a
+    // single-threaded tokio runtime.  So we have to wrap it in a silly Mutex.
+    cap_nfs_agent: Mutex<CapNfsAgent>,
+}
+
+/// Wrapper type that implements IntoResponse for io::Error.
+#[derive(Debug)]
+struct AppError(io::Error);
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        (StatusCode::INTERNAL_SERVER_ERROR, format!("{}", self.0))
+            .into_response()
+    }
+}
+
+// Create metrics
+// Even though these are really counters, we use the Gauge API since the
+// kernel reports their current values and prometheus::Counter only has an
+// inc method, not a set method.
+// And even though they're integers, we must use the f64 gauge type because
+// prometheus::IntCounter wraps i64 instead of u64.  The loss of precision
+// is unavoidable because Prometheus itself treats all metrics as f64
+// anyway.
+static BYTES: LazyLock<GaugeVec> = LazyLock::new(|| {
+    register_gauge_vec!(
+        "nfs_nfsd_total_bytes",
+        "Total nfsd bytes per operation",
+        &["method"]
+    )
+    .expect("cannot create gauge")
+});
+static DURATION: LazyLock<GaugeVec> = LazyLock::new(|| {
+    register_gauge_vec!(
+        "nfs_nfsd_total_duration",
+        "Total nfsd nanoseconds spend processing each operation.  May wrap.",
+        &["method"]
+    )
+    .expect("cannot create gauge")
+});
+static RPCS: LazyLock<GaugeVec> = LazyLock::new(|| {
+    register_gauge_vec!(
+        "nfs_nfsd_requests_total",
+        "Count of server RPCs",
+        &["method"]
+    )
+    .expect("cannot create gauge")
+});
+static STARTCNT: LazyLock<Gauge> = LazyLock::new(|| {
+    register_gauge!(
+        "nfs_nfsd_start_count",
+        "Total number of opreations started since boot"
+    )
+    .expect("cannot create gauge")
+});
+static DONECNT: LazyLock<Gauge> = LazyLock::new(|| {
+    register_gauge!(
+        "nfs_nfsd_done_count",
+        "Total number of opreations completed since boot"
+    )
+    .expect("cannot create gauge")
+});
+static BUSYTIME: LazyLock<Gauge> = LazyLock::new(|| {
+    register_gauge!(
+        "nfs_nfsd_busytime",
+        "Total time in ns that nfsd was busy with at least one opeartion"
+    )
+    .expect("cannot create gauge")
+});
+static CACHE_INPROG: LazyLock<Gauge> = LazyLock::new(|| {
+    register_gauge!(
+        "nfs_nfsd_cache_in_progress_hits",
+        "Server cache in-progress hits"
+    )
+    .expect("cannot create gauge")
+});
+// Don't publish Idem.  It's always 0
+static CACHE_NONIDEMPOTENT: LazyLock<Gauge> = LazyLock::new(|| {
+    register_gauge!(
+        "nfs_nfsd_cache_nonidempotent_hits",
+        "Server cache non-idempotent hits"
+    )
+    .expect("cannot create gauge")
+});
+static CACHE_MISSES: LazyLock<Gauge> = LazyLock::new(|| {
+    register_gauge!("nfs_nfsd_server_cache_misses", "Server cache misses")
+        .expect("cannot create gauge")
+});
+static CACHE_SIZE: LazyLock<Gauge> = LazyLock::new(|| {
+    register_gauge!(
+        "nfs_nfsd_server_cache_size",
+        "Server cache size in entries"
+    )
+    .expect("cannot create gauge")
+});
+static CACHE_TCPPEAK: LazyLock<Gauge> = LazyLock::new(|| {
+    register_gauge!(
+        "nfs_nfsd_server_cache_tcp_peak",
+        "Peak size of the NFS server's TCP client cache"
+    )
+    .expect("cannot create gauge")
+});
+static CLIENTS: LazyLock<Gauge> = LazyLock::new(|| {
+    register_gauge!("nfs_nfsd_clients", "Number of connected NFS v4.x clients")
+        .expect("cannot create gauge")
+});
+static DELEGS: LazyLock<Gauge> = LazyLock::new(|| {
+    register_gauge!("nfs_nfsd_delegations", "Number of active NFS delegations")
+        .expect("cannot create gauge")
+});
+static LOCK_OWNER: LazyLock<Gauge> = LazyLock::new(|| {
+    register_gauge!("nfs_nfsd_lock_owners", "Number of active NFS lock owners")
+        .expect("cannot create gauge")
+});
+static LOCKS: LazyLock<Gauge> = LazyLock::new(|| {
+    register_gauge!("nfs_nfsd_locks", "Number of active NFS locks")
+        .expect("cannot create gauge")
+});
+static OPEN_OWNER: LazyLock<Gauge> = LazyLock::new(|| {
+    register_gauge!(
+        "nfs_nfsd_open_owners",
+        "Number of active NFS v4.0 Open Owners"
+    )
+    .expect("cannot create gauge")
+});
+static OPENS: LazyLock<Gauge> = LazyLock::new(|| {
+    register_gauge!("nfs_nfsd_opens", "Number of NFS v4.x open files?")
+        .expect("cannot create gauge")
+});
+
+async fn metrics(
+    addr: ConnectInfo<SocketAddr>,
+    state: State<Arc<AppState>>,
+) -> Result<String, AppError> {
+    let ip = addr.ip();
+    log::debug!("Servicing request from {ip}");
+
+    let nfs_stat = state.cap_nfs_agent.lock().unwrap().nfsstat().unwrap();
+
+    if state.server {
+        macro_rules! set_rpcs {
+            ($label:ident, $field:ident) => {
+                RPCS.with_label_values(&[stringify!($label)])
+                    .set(nfs_stat.server_rpcs.$field as f64);
+            };
+        }
+
+        BYTES
+            .with_label_values(&["Read"])
+            .set(nfs_stat.bytes.read as f64);
+        BYTES
+            .with_label_values(&["Write"])
+            .set(nfs_stat.bytes.write as f64);
+        DURATION
+            .with_label_values(&["Read"])
+            .set(nfs_stat.duration.read as f64);
+        DURATION
+            .with_label_values(&["Write"])
+            .set(nfs_stat.duration.write as f64);
+        DURATION
+            .with_label_values(&["Commit"])
+            .set(nfs_stat.duration.commit as f64);
+        STARTCNT.set(nfs_stat.startcnt as f64);
+        DONECNT.set(nfs_stat.donecnt as f64);
+        BUSYTIME.set(nfs_stat.busytime as f64);
+
+        CACHE_INPROG.set(nfs_stat.server_cache.inprog as f64);
+        CACHE_NONIDEMPOTENT.set(nfs_stat.server_cache.nonidem as f64);
+        CACHE_MISSES.set(nfs_stat.server_cache.misses as f64);
+        CACHE_SIZE.set(nfs_stat.server_cache.size as f64);
+        CACHE_TCPPEAK.set(nfs_stat.server_cache.tcp_peak as f64);
+
+        CLIENTS.set(nfs_stat.server_misc.clients as f64);
+        DELEGS.set(nfs_stat.server_misc.delegs as f64);
+        LOCK_OWNER.set(nfs_stat.server_misc.lock_owner as f64);
+        LOCKS.set(nfs_stat.server_misc.locks as f64);
+        OPEN_OWNER.set(nfs_stat.server_misc.open_owner as f64);
+        OPENS.set(nfs_stat.server_misc.opens as f64);
+
+        set_rpcs!(Access, access);
+        set_rpcs!(BackChannelCtl, backchannelctrl);
+        set_rpcs!(BindConnToSess, bindconntosess);
+        set_rpcs!(Close, close);
+        set_rpcs!(Commit, commit);
+        set_rpcs!(Create, v3create);
+        set_rpcs!(CreateSession, createsess);
+        set_rpcs!(CreateV4, create);
+        set_rpcs!(DelegPurge, delegpurge);
+        set_rpcs!(DelegReturn, delegreturn);
+        set_rpcs!(DestroyClientId, destroyclid);
+        set_rpcs!(DestroySession, destroysess);
+        set_rpcs!(ExchangeId, exchangeid);
+        set_rpcs!(FreeStateId, freestateid);
+        set_rpcs!(FsInfo, fsinfo);
+        set_rpcs!(FsStat, fsstat);
+        set_rpcs!(GetAttr, getattr);
+        set_rpcs!(GetDevInfo, getdevinfo);
+        set_rpcs!(GetDevList, getdevlist);
+        set_rpcs!(GetDirDeleg, getdirdeleg);
+        set_rpcs!(GetFH, getfh);
+        set_rpcs!(LayoutCommit, layoutcommit);
+        set_rpcs!(LayoutGet, layoutget);
+        set_rpcs!(LayoutReturn, layoutreturn);
+        set_rpcs!(Link, link);
+        set_rpcs!(Lock, lock);
+        set_rpcs!(LockT, lockt);
+        set_rpcs!(LockU, locku);
+        set_rpcs!(Lookup, lookup);
+        set_rpcs!(LookupP, lookupp);
+        set_rpcs!(MkDir, mkdir);
+        set_rpcs!(MkNod, mknod);
+        set_rpcs!(Nverify, nverify);
+        set_rpcs!(Open, open);
+        set_rpcs!(OpenAttr, openattr);
+        set_rpcs!(OpenConfirm, openconfirm);
+        set_rpcs!(OpenDgrd, opendgrd);
+        set_rpcs!(PathConf, pathconf);
+        set_rpcs!(PutFH, putfh);
+        set_rpcs!(Read, read);
+        set_rpcs!(ReadDir, readdir);
+        set_rpcs!(ReadDirPlus, readdirplus);
+        set_rpcs!(ReadLink, readlink);
+        set_rpcs!(ReclaimCompl, reclaimcompl);
+        set_rpcs!(RelLockOwner, rellckown);
+        set_rpcs!(Remove, remove);
+        set_rpcs!(Rename, rename);
+        set_rpcs!(Renew, renew);
+        set_rpcs!(RestoreFH, restorefh);
+        set_rpcs!(RmDir, rmdir);
+        set_rpcs!(SaveFH, savefh);
+        set_rpcs!(SecInfo, secinfo);
+        set_rpcs!(SecInfoNoName, secinfononame);
+        set_rpcs!(Sequence, sequence);
+        set_rpcs!(SetAttr, setattr);
+        set_rpcs!(SetClientId, setclid);
+        set_rpcs!(SetClientIdConfirm, setclidcf);
+        set_rpcs!(SetSSV, setssv);
+        set_rpcs!(SymLink, symlink);
+        set_rpcs!(TestStateId, teststateid);
+        set_rpcs!(Verify, verify);
+        set_rpcs!(WantDeleg, wantdeleg);
+        set_rpcs!(Write, write);
+    }
+    let metric_families = prometheus::gather();
+    let encoder = TextEncoder::new();
+    let body = encoder.encode_to_string(&metric_families).expect("TODO");
+    Ok(body)
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let cli = Cli::parse();
     let (_c, s) = if !cli.client && !cli.server {
         // By default, print everything
@@ -46,8 +317,6 @@ fn main() {
             .exit()
     };
 
-    // Setup logger with default level info so we can see the messages from
-    // prometheus_exporter.
     Builder::from_env(Env::default().default_filter_or("info")).init();
 
     // Parse address used to bind exporter to.
@@ -56,217 +325,28 @@ fn main() {
 
     // Start Casper .  Safe because we're still single-threaded.
     let mut casper = unsafe { Casper::new().unwrap() };
-    let mut cap_nfs = casper.nfsstat().unwrap();
+    let cap_nfs_agent = Mutex::new(casper.nfsstat().unwrap());
 
-    // Start exporter, which creates additional threads.
-    let exporter = prometheus_exporter::start(sa).unwrap();
+    let listener = TcpListener::bind(sa).await.unwrap_or_else(|e| {
+        eprintln!("Error starting exporter: {e}");
+        exit(1);
+    });
+
+    let state = AppState {
+        server: s,
+        cap_nfs_agent,
+    };
 
     // Enter capability mode.
     capsicum::enter().unwrap();
 
-    // Create metrics
-    // Even though these are really counters, we use the Gauge API since the
-    // kernel reports their current values and prometheus::Counter only has an
-    // inc method, not a set method.
-    // And even though they're integers, we must use the f64 gauge type because
-    // prometheus::IntCounter wraps i64 instead of u64.  The loss of precision
-    // is unavoidable because Prometheus itself treats all metrics as f64
-    // anyway.
-    let bytes = register_gauge_vec!(
-        "nfs_nfsd_total_bytes",
-        "Total nfsd bytes per operation",
-        &["method"]
-    )
-    .expect("cannot create gauge");
-    let duration = register_gauge_vec!(
-        "nfs_nfsd_total_duration",
-        "Total nfsd nanoseconds spend processing each operation.  May wrap.",
-        &["method"]
-    )
-    .expect("cannot create gauge");
-    let rpcs = register_gauge_vec!(
-        "nfs_nfsd_requests_total",
-        "Count of server RPCs",
-        &["method"]
-    )
-    .expect("cannot create gauge");
-    let startcnt = register_gauge!(
-        "nfs_nfsd_start_count",
-        "Total number of opreations started since boot"
-    )
-    .expect("cannot create gauge");
-    let donecnt = register_gauge!(
-        "nfs_nfsd_done_count",
-        "Total number of opreations completed since boot"
-    )
-    .expect("cannot create gauge");
-    let busytime = register_gauge!(
-        "nfs_nfsd_busytime",
-        "Total time in ns that nfsd was busy with at least one opeartion"
-    )
-    .expect("cannot create gauge");
+    let app = Router::new()
+        .route("/metrics", get(metrics))
+        // Annoyingly, with_state requires its argument to be `Send` even if
+        // we're using a single-threaded runtime.  So we must use Arc instead of
+        // Rc.
+        .with_state(Arc::new(state))
+        .into_make_service_with_connect_info::<SocketAddr>();
 
-    let cache_inprog = register_gauge!(
-        "nfs_nfsd_cache_in_progress_hits",
-        "Server cache in-progress hits"
-    )
-    .expect("cannot create gauge");
-    // Don't publish Idem.  It's always 0
-    let cache_nonidempotent = register_gauge!(
-        "nfs_nfsd_cache_nonidempotent_hits",
-        "Server cache non-idempotent hits"
-    )
-    .expect("cannot create gauge");
-    let cache_misses =
-        register_gauge!("nfs_nfsd_server_cache_misses", "Server cache misses")
-            .expect("cannot create gauge");
-    let cache_size = register_gauge!(
-        "nfs_nfsd_server_cache_size",
-        "Server cache size in entries"
-    )
-    .expect("cannot create gauge");
-    let cache_tcppeak = register_gauge!(
-        "nfs_nfsd_server_cache_tcp_peak",
-        "Peak size of the NFS server's TCP client cache"
-    )
-    .expect("cannot create gauge");
-
-    let clients = register_gauge!(
-        "nfs_nfsd_clients",
-        "Number of connected NFS v4.x clients"
-    )
-    .expect("cannot create gauge");
-    let delegs = register_gauge!(
-        "nfs_nfsd_delegations",
-        "Number of active NFS delegations"
-    )
-    .expect("cannot create gauge");
-    let lock_owner = register_gauge!(
-        "nfs_nfsd_lock_owners",
-        "Number of active NFS lock owners"
-    )
-    .expect("cannot create gauge");
-    let locks = register_gauge!("nfs_nfsd_locks", "Number of active NFS locks")
-        .expect("cannot create gauge");
-    let open_owner = register_gauge!(
-        "nfs_nfsd_open_owners",
-        "Number of active NFS v4.0 Open Owners"
-    )
-    .expect("cannot create gauge");
-    let opens =
-        register_gauge!("nfs_nfsd_opens", "Number of NFS v4.x open files?")
-            .expect("cannot create gauge");
-
-    loop {
-        // Will block until exporter receives http request.
-        let _guard = exporter.wait_request();
-
-        // Update metric with random value.
-        let nfs_stat = cap_nfs.nfsstat().unwrap();
-
-        if s {
-            macro_rules! set_rpcs {
-                ($label:ident, $field:ident) => {
-                    rpcs.with_label_values(&[stringify!($label)])
-                        .set(nfs_stat.server_rpcs.$field as f64);
-                };
-            }
-
-            bytes
-                .with_label_values(&["Read"])
-                .set(nfs_stat.bytes.read as f64);
-            bytes
-                .with_label_values(&["Write"])
-                .set(nfs_stat.bytes.write as f64);
-            duration
-                .with_label_values(&["Read"])
-                .set(nfs_stat.duration.read as f64);
-            duration
-                .with_label_values(&["Write"])
-                .set(nfs_stat.duration.write as f64);
-            duration
-                .with_label_values(&["Commit"])
-                .set(nfs_stat.duration.commit as f64);
-            startcnt.set(nfs_stat.startcnt as f64);
-            donecnt.set(nfs_stat.donecnt as f64);
-            busytime.set(nfs_stat.busytime as f64);
-
-            cache_inprog.set(nfs_stat.server_cache.inprog as f64);
-            cache_nonidempotent.set(nfs_stat.server_cache.nonidem as f64);
-            cache_misses.set(nfs_stat.server_cache.misses as f64);
-            cache_size.set(nfs_stat.server_cache.size as f64);
-            cache_tcppeak.set(nfs_stat.server_cache.tcp_peak as f64);
-
-            clients.set(nfs_stat.server_misc.clients as f64);
-            delegs.set(nfs_stat.server_misc.delegs as f64);
-            lock_owner.set(nfs_stat.server_misc.lock_owner as f64);
-            locks.set(nfs_stat.server_misc.locks as f64);
-            open_owner.set(nfs_stat.server_misc.open_owner as f64);
-            opens.set(nfs_stat.server_misc.opens as f64);
-
-            set_rpcs!(Access, access);
-            set_rpcs!(BackChannelCtl, backchannelctrl);
-            set_rpcs!(BindConnToSess, bindconntosess);
-            set_rpcs!(Close, close);
-            set_rpcs!(Commit, commit);
-            set_rpcs!(Create, v3create);
-            set_rpcs!(CreateSession, createsess);
-            set_rpcs!(CreateV4, create);
-            set_rpcs!(DelegPurge, delegpurge);
-            set_rpcs!(DelegReturn, delegreturn);
-            set_rpcs!(DestroyClientId, destroyclid);
-            set_rpcs!(DestroySession, destroysess);
-            set_rpcs!(ExchangeId, exchangeid);
-            set_rpcs!(FreeStateId, freestateid);
-            set_rpcs!(FsInfo, fsinfo);
-            set_rpcs!(FsStat, fsstat);
-            set_rpcs!(GetAttr, getattr);
-            set_rpcs!(GetDevInfo, getdevinfo);
-            set_rpcs!(GetDevList, getdevlist);
-            set_rpcs!(GetDirDeleg, getdirdeleg);
-            set_rpcs!(GetFH, getfh);
-            set_rpcs!(LayoutCommit, layoutcommit);
-            set_rpcs!(LayoutGet, layoutget);
-            set_rpcs!(LayoutReturn, layoutreturn);
-            set_rpcs!(Link, link);
-            set_rpcs!(Lock, lock);
-            set_rpcs!(LockT, lockt);
-            set_rpcs!(LockU, locku);
-            set_rpcs!(Lookup, lookup);
-            set_rpcs!(LookupP, lookupp);
-            set_rpcs!(MkDir, mkdir);
-            set_rpcs!(MkNod, mknod);
-            set_rpcs!(Nverify, nverify);
-            set_rpcs!(Open, open);
-            set_rpcs!(OpenAttr, openattr);
-            set_rpcs!(OpenConfirm, openconfirm);
-            set_rpcs!(OpenDgrd, opendgrd);
-            set_rpcs!(PathConf, pathconf);
-            set_rpcs!(PutFH, putfh);
-            set_rpcs!(Read, read);
-            set_rpcs!(ReadDir, readdir);
-            set_rpcs!(ReadDirPlus, readdirplus);
-            set_rpcs!(ReadLink, readlink);
-            set_rpcs!(ReclaimCompl, reclaimcompl);
-            set_rpcs!(RelLockOwner, rellckown);
-            set_rpcs!(Remove, remove);
-            set_rpcs!(Rename, rename);
-            set_rpcs!(Renew, renew);
-            set_rpcs!(RestoreFH, restorefh);
-            set_rpcs!(RmDir, rmdir);
-            set_rpcs!(SaveFH, savefh);
-            set_rpcs!(SecInfo, secinfo);
-            set_rpcs!(SecInfoNoName, secinfononame);
-            set_rpcs!(Sequence, sequence);
-            set_rpcs!(SetAttr, setattr);
-            set_rpcs!(SetClientId, setclid);
-            set_rpcs!(SetClientIdConfirm, setclidcf);
-            set_rpcs!(SetSSV, setssv);
-            set_rpcs!(SymLink, symlink);
-            set_rpcs!(TestStateId, teststateid);
-            set_rpcs!(Verify, verify);
-            set_rpcs!(WantDeleg, wantdeleg);
-            set_rpcs!(Write, write);
-        }
-    }
+    axum::serve(listener, app).await.unwrap()
 }


### PR DESCRIPTION
This replaces prometheus-exporter/tiny-http with prometheus/axum. The former pair are unmaintained and have bugs with no released solutions.

Fixes #42