### PR TITLE
Simplify CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,20 +41,17 @@ jobs:
         shell: freebsd {0}
         run: |
           . $HOME/.cargo/env
-          cd $GITHUB_WORKSPACE
           cargo build
       - name: Test
         shell: freebsd {0}
         run: |
           . $HOME/.cargo/env
-          cd $GITHUB_WORKSPACE
           cargo test
       - name: Clippy
         if: matrix.rust_version == 'nightly'
         shell: freebsd {0}
         run: |
           . $HOME/.cargo/env
-          cd $GITHUB_WORKSPACE
           rustup component add clippy
           cargo clippy --all-targets -- -D warnings
       - name: Fmt
@@ -62,7 +59,6 @@ jobs:
         shell: freebsd {0}
         run: |
           . $HOME/.cargo/env
-          cd $GITHUB_WORKSPACE
           rustup component add rustfmt
           cargo fmt --all -- --check --color=never
       - name: Audit
@@ -70,7 +66,6 @@ jobs:
         shell: freebsd {0}
         run: |
           . $HOME/.cargo/env
-          cd $GITHUB_WORKSPACE
           pkg install -y cargo-audit
           cargo audit
       - name: Minver
@@ -78,6 +73,5 @@ jobs:
         shell: freebsd {0}
         run: |
           . $HOME/.cargo/env
-          cd $GITHUB_WORKSPACE
           cargo update -Zdirect-minimal-versions
           cargo check --all-targets


### PR DESCRIPTION
The "cd ${GITHUB_WORKSPACE}" command is no longer needed in the latest version of vmactions/freebsd-vm , published today.